### PR TITLE
Enhance status handling -- allow use of ${{ job.status }}

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This action lets you easily update status of a Deployment on GitHub. Learn more 
 
 | Name            | Required | Default value  | Description                                                                                                                                                                                                                                               |
 |-----------------|----------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| status          | yes      | N/A            | Desired status of the Deployment. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued`, `pending` or `success`                                                                                                                           |
+| status          | no       | `in_progress`  | Desired status of the Deployment. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued`, `pending` or `success`                                                                                                                           |
 | description     | no       | <empty string> | A short description of the status. The maximum description length is 140 characters.                                                                                                                                                                      |
 | auto_inactive   | no       | true           | Adds a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment name as the created status's deployment. An inactive status is only added to deployments that had a success state. |
 | environment_url | no       | <empty string> | Sets the URL for accessing your environment.                                                                                                                                                                                                              |
@@ -39,8 +39,6 @@ jobs:
       - id: set_state_in_progress
         name: Set deployment status to [in_progress]
         uses: rsotnychenko/deployment-status-update@0.1.0
-        with:
-          status: in_progress
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GAE

--- a/README.md
+++ b/README.md
@@ -50,19 +50,12 @@ jobs:
           APPLICATION_CREDENTIALS: ${{ secrets.GCLOUD_TOKEN }}
         with:
           args: app deploy
-      - id: set_state_success
-        name: Set deployment status to [success]
+      - id: set_state_final
+        if: always()
+        name: Set deployment status
         uses: rsotnychenko/deployment-status-update@0.1.0
         with:
-          status: success
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - id: set_state_error
-        name: Set deployment status to [error]
-        if: failure()
-        uses: rsotnychenko/deployment-status-update@0.1.0
-        with:
-          status: error
+          status: ${{ job.status }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # TODO: Add rollback operations

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,11 @@ get_from_event() {
 
 GITHUB_API_DEPLOYMENTS_URL="$(get_from_event '.deployment.statuses_url')"
 GITHUB_ACTIONS_URL="$(get_from_event '.repository.html_url')/actions"
+INPUT_STATUS=$(echo "$INPUT_STATUS" | tr '[:upper:]' '[:lower:]')
+if [ "$INPUT_STATUS" = cancelled ] ; then
+    echo "Rewriting status from cancelled to error"
+    INPUT_STATUS=error
+fi
 
 curl --fail \
     -X POST "${GITHUB_API_DEPLOYMENTS_URL}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ "${GITHUB_EVENT_NAME}" != "deployment" ]; then
 fi
 
 get_from_event() {
-  echo "$(jq -r "$1" ${GITHUB_EVENT_PATH})"
+  jq -r "$1" "${GITHUB_EVENT_PATH}"
 }
 
 GITHUB_API_DEPELOYMENTS_URL="$(get_from_event '.deployment.statuses_url')"
@@ -34,4 +34,3 @@ echo ::set-output name=ref::$(get_from_event '.deployment.ref')
 echo ::set-output name=sha::$(get_from_event '.deployment.sha')
 echo ::set-output name=environment::$(get_from_event '.deployment.environment')
 echo ::set-output name=payload::$(get_from_event '.deployment.payload')
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,11 @@ get_from_event() {
   jq -r "$1" "${GITHUB_EVENT_PATH}"
 }
 
-GITHUB_API_DEPELOYMENTS_URL="$(get_from_event '.deployment.statuses_url')"
+GITHUB_API_DEPLOYMENTS_URL="$(get_from_event '.deployment.statuses_url')"
 GITHUB_ACTIONS_URL="$(get_from_event '.repository.html_url')/actions"
 
 curl --fail \
-    -X POST "${GITHUB_API_DEPELOYMENTS_URL}" \
+    -X POST "${GITHUB_API_DEPLOYMENTS_URL}" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: text/json; charset=utf-8" \
     -H "Accept: application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ EOF
 
 echo ::set-output name=deployment_id::$(get_from_event '.deployment.id')
 echo ::set-output name=description::$(get_from_event '.deployment.description')
-echo ::set-output name=state::${INPUT_STATUS}
+echo ::set-output name=state::${INPUT_STATUS:-in_progress}
 echo ::set-output name=ref::$(get_from_event '.deployment.ref')
 echo ::set-output name=sha::$(get_from_event '.deployment.sha')
 echo ::set-output name=environment::$(get_from_event '.deployment.environment')


### PR DESCRIPTION
Lets you do this:

```yaml
      - id: set_state_success
        if: always()
        name: Set deployment status
        uses: rsotnychenko/deployment-status-update@0.1.0
        with:
          status: ${{ job.status }}
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Examples of this working from a private repo I've been working on:

![Screen Shot 2020-02-28 at 11 03 56 am-fs8](https://user-images.githubusercontent.com/379509/75498232-b9bc5b00-5a1a-11ea-8d34-b2ab57e13b7d.png)
![Screen Shot 2020-02-28 at 11 05 22 am-fs8](https://user-images.githubusercontent.com/379509/75498234-bb861e80-5a1a-11ea-8bec-9bfe18c91898.png)
