### PR TITLE
Convert object payloads to string

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,4 +52,4 @@ echo "state=${INPUT_STATUS}" >> $GITHUB_OUTPUT
 echo "ref=$(get_from_event '.deployment.ref')" >> $GITHUB_OUTPUT
 echo "sha=$(get_from_event '.deployment.sha')" >> $GITHUB_OUTPUT
 echo "environment=$(get_from_event '.deployment.environment')" >> $GITHUB_OUTPUT
-echo "payload=$(get_from_event '.deployment.payload')" >> $GITHUB_OUTPUT
+echo "payload=$(get_from_event '.deployment.payload|tostring')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The GitHub documentation for Deployments says that the `payload` can be "object or string". When setting the payload to an object this Action fails with 
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '  "namespace": "default"'
```
This is due to the output being placed across multiple lines
```
+ jq -r .deployment.payload /github/workflow/event.json
+ echo 'payload={
  "namespace": "default"
}'
```
By adding the `tostring` function the error is fixed.
```
+ jq -r '.deployment.payload|tostring' /github/workflow/event.json
+ echo 'payload={"namespace":"default"}'
```