### PR TITLE
fix: use multiline syntax for payload output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,4 +52,8 @@ echo "state=${INPUT_STATUS}" >> $GITHUB_OUTPUT
 echo "ref=$(get_from_event '.deployment.ref')" >> $GITHUB_OUTPUT
 echo "sha=$(get_from_event '.deployment.sha')" >> $GITHUB_OUTPUT
 echo "environment=$(get_from_event '.deployment.environment')" >> $GITHUB_OUTPUT
-printf 'payload<<%s\n%s\n%s\n' "EOF" "$(get_from_event '.deployment.payload')" "EOF" >> "$GITHUB_OUTPUT"
+{
+  echo 'payload<<EOF'
+  get_from_event '.deployment.payload'
+  echo EOF
+} >> "$GITHUB_OUTPUT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,4 +52,4 @@ echo "state=${INPUT_STATUS}" >> $GITHUB_OUTPUT
 echo "ref=$(get_from_event '.deployment.ref')" >> $GITHUB_OUTPUT
 echo "sha=$(get_from_event '.deployment.sha')" >> $GITHUB_OUTPUT
 echo "environment=$(get_from_event '.deployment.environment')" >> $GITHUB_OUTPUT
-echo "payload=$(get_from_event '.deployment.payload')" >> $GITHUB_OUTPUT
+printf 'payload<<%s\n%s\n%s\n' "EOF" "$(get_from_event '.deployment.payload')" "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes #8.

`0.2.1` writes the deployment `payload` to `$GITHUB_OUTPUT` using a plain `echo`, which fails when the payload is multi-line JSON (e.g. pretty-printed). GitHub Actions rejects multi-line values written via plain `echo`.

The fix uses the [recommended heredoc delimiter syntax](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings):

```sh
{
  echo 'payload<<EOF'
  get_from_event '.deployment.payload'
  echo EOF
} >> "$GITHUB_OUTPUT"
```